### PR TITLE
Additional python3 support

### DIFF
--- a/readthedocs_ext/comments/directive.py
+++ b/readthedocs_ext/comments/directive.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from collections import defaultdict
 from docutils import nodes
 from docutils.parsers.rst import Directive
@@ -22,7 +24,7 @@ class CommentConfigurationDirective(Directive):
         if not hasattr(env, 'comment_config_map'):
             env.comment_config_map = defaultdict(set)
         for option in self.arguments:
-            print 'OPTION %s' % option
+            print('OPTION %s' % option)
             if option in ['none', 'header', 'paragraph', 'code']:
                 env.comment_config_map[docname].add(option)
             else:

--- a/readthedocs_ext/comments/translator.py
+++ b/readthedocs_ext/comments/translator.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 from sphinx.writers.html import HTMLTranslator
 
-import hasher
+from . import hasher
 
 # Between 128 and -128, the higher the number, the closer the strings are
 LENGTH_LIMIT = 30

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import codecs
 try:
     from setuptools import setup, find_packages
     extra_setup = dict(
-        install_requires=['requests', 'nilsimsa'],
+        install_requires=['requests', 'nilsimsa>=0.3.7'],
     )
 except ImportError:
     from distutils.core import setup
@@ -10,7 +10,7 @@ except ImportError:
 
 setup(
     name='readthedocs-sphinx-ext',
-    version='0.5.3',
+    version='0.5.4',
     author='Eric Holscher',
     author_email='eric@ericholscher.com',
     url='http://github.com/ericholscher/readthedocs-sphinx-ext',


### PR DESCRIPTION
Bumps nilsimsa version to 0.3.7, a version with python3 support. This also updates a few calls that were python2 only. Bumps our version to `0.5.4`

Fixes #8 