### PR TITLE
Switch to Universal Analytics API

### DIFF
--- a/readthedocs_ext/_static/readthedocs-dynamic-include.js_t
+++ b/readthedocs_ext/_static/readthedocs-dynamic-include.js_t
@@ -1,21 +1,19 @@
 // RTD Analytics Code
 
-var _gaq = _gaq || [];
-_gaq.push(['_setAccount', '{{ global_analytics_code }}']);
-_gaq.push(['_trackPageview']);
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+ga('create', '{{ global_analytics_code }}', 'auto', 'rtfd');
+ga('rtfd.send', 'pageview');
 
 {% if user_analytics_code %}
 // User Analytics Code
-_gaq.push(['user._setAccount', '{{ user_analytics_code }}']);
-_gaq.push(['user._trackPageview']);
+ga('create', '{{ user_analytics_code }}', 'auto', 'user');
+ga('user.send', 'pageview');
 // End User Analytics Code
 {% endif %}
-
-(function() {
-var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-})();
 
 // end RTD Analytics Code
 


### PR DESCRIPTION
- Switches from legacy `ga.js` to new `analytics.js`, in parrallel with rtfd/readthedocs.org#3085
- Google Analytics script element has been moved from the bottom of the page to top of `<head>` as per [Googles instructions](https://developers.google.com/analytics/devguides/collection/analyticsjs/#the_javascript_tracking_snippet)
- Could be made faster by directly adding the Analytics snippet in the html, rather than letting the browser request `readthedocs-dynamic-include.js_t`, which contains the snippet
- Not using the [Alternative async tracking snippet](https://developers.google.com/analytics/devguides/collection/analyticsjs/#alternative_async_tracking_snippet) which should be a bit faster but "can degrade to synchronous loading and execution on IE 9 and older mobile browsers that do not recognise the async script attribute"
- Needs to be tested by someone with access to RTFD Analytics