### PR TITLE
Add programming language to READTHEDOCS_DATA

### DIFF
--- a/readthedocs_ext/_static/readthedocs-data.js_t
+++ b/readthedocs_ext/_static/readthedocs-data.js_t
@@ -2,6 +2,7 @@
     project: "{{ slug }}",
     version: "{{ version_slug }}",
     language: "{{ rtd_language }}",
+    programming_language: "{{ programming_language }}",
     subprojects: {},
     canonical_url: "{{ canonical_url }}",
     theme: "{{ html_theme }}",


### PR DESCRIPTION
Now that the programming language is in the API response (since https://github.com/rtfd/readthedocs.org/pull/3499), we can add it to `READTHEDOCS_DATA`.