### PR TITLE
Stop injecting the theme CSS on the RTD theme

### DIFF
--- a/prospector.yml
+++ b/prospector.yml
@@ -15,6 +15,8 @@ pylint:
   options:
     dummy-variables-rgx: '_$|__$|dummy'
     max-line-length: 100
+    # https://github.com/PyCQA/pylint/issues/73
+    ignored-modules: distutils
   disable:
     - logging-format-interpolation
 

--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -6,6 +6,7 @@ import codecs
 import os
 import re
 import types
+from distutils.version import LooseVersion
 
 import sphinx
 from sphinx import package_dir
@@ -70,7 +71,18 @@ def update_body(app, pagename, templatename, context, doctree):
         # Only insert on our HTML builds
         return
 
-    if theme_css not in app.builder.css_files:
+    inject_css = True
+
+    # After v0.3.0 of the sphinx theme, the theme CSS should not be injected
+    # This decouples the theme CSS (which is versioned independently) from readthedocs.org
+    if theme_css.endswith('sphinx_rtd_theme.css'):
+        try:
+            import sphinx_rtd_theme
+            inject_css = LooseVersion(sphinx_rtd_theme.__version__) <= LooseVersion('0.3.0')
+        except ImportError:
+            pass
+
+    if inject_css and theme_css not in app.builder.css_files:
         app.builder.css_files.insert(0, theme_css)
 
     # This is monkey patched on the signal because we can't know what the user

--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -73,12 +73,12 @@ def update_body(app, pagename, templatename, context, doctree):
 
     inject_css = True
 
-    # After v0.3.0 of the sphinx theme, the theme CSS should not be injected
+    # Starting at v0.4.0 of the sphinx theme, the theme CSS should not be injected
     # This decouples the theme CSS (which is versioned independently) from readthedocs.org
     if theme_css.endswith('sphinx_rtd_theme.css'):
         try:
             import sphinx_rtd_theme
-            inject_css = LooseVersion(sphinx_rtd_theme.__version__) <= LooseVersion('0.3.0')
+            inject_css = LooseVersion(sphinx_rtd_theme.__version__) < LooseVersion('0.4.0')
         except ImportError:
             pass
 


### PR DESCRIPTION
This performs a version check on the Read the Docs theme and only injects the `theme.css` for older versions of the theme. The goal here is to break the tight coupling between the bundled code on readthedocs.org and the theme.css. Previously, the theme did not include the CSS if it was being built on Read the Docs. With this change, the theme CSS can be updated independently of Read the Docs.

Related to https://github.com/rtfd/sphinx_rtd_theme/pull/614 but that PR does not strictly require this one. Without this change, both CSS files (a local one and one from readthedocs.org) will be included on theme versions >0.3.0.