### PR TITLE
Bump version for 0.5.11

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:
 
 setup(
     name='readthedocs-sphinx-ext',
-    version='0.5.10',
+    version='0.5.11',
     author='Eric Holscher',
     author_email='eric@ericholscher.com',
     url='http://github.com/ericholscher/readthedocs-sphinx-ext',


### PR DESCRIPTION
I assume that the release process is as simple as:

    $ rm -rf dist
    $ python setup.py sdist bdist_wheel
    $ twine upload dist/*