### PR TITLE
Document steps for releasing and pushing to PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,3 +9,18 @@ We currently ship:
 
 * An extension for building docs like Read the Docs
 * ``template-meta`` - Allows users to specify template overrides in per-page context.
+
+
+Releasing
+---------
+
+#. Increment the version in ``setup.py``
+#. Tag the release in git: ``git tag $NEW_VERSION``.
+#. Push the tag to GitHub: ``git push --tags origin``
+#. Upload the package to PyPI:
+
+    .. code:: bash
+
+        $ rm -rf dist/
+        $ python setup.py sdist bdist_wheel
+        $ twine upload --sign --identity security@readthedocs.org dist/*


### PR DESCRIPTION
This is a documentation update around releasing:

- Use Twine to ensure the upload is HTTPS (this normally isn't an issue)
- Signing the release with the [RTD PGP key](https://docs.readthedocs.io/en/latest/security.html#pgp-key)