### PR TITLE
Don't output `rellinks` in the JSON extension

### DIFF
--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -40,7 +40,6 @@ KEYS = [
     'title',
     'sourcename',
     'current_page_name',
-    'rellinks',
     'toc',
     'page_source_suffix',
 ]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -68,7 +68,7 @@ class IntegrationTests(LanguageIntegrationTests):
             '_build/json/index.fjson',
             [
                 'current_page_name', 'title', 'body',
-                'toc', 'sourcename', 'rellinks', 'page_source_suffix',
+                'toc', 'sourcename', 'page_source_suffix',
             ],
         )
 


### PR DESCRIPTION
This was causing an error with Sphinx passing in things that aren't JSON encodable.
Let's just not output it for now,
since we aren't indexing it in search currently.

Error:

```
ipdb> to_context['rellinks'][2]
('py-modindex', iu'Python Module Index', '', iu'modules')
ipdb> to_context['rellinks'][2][1]
iu'Python Module Index'
ipdb> type(to_context['rellinks'][2][1])
<class 'sphinx.locale._TranslationProxy'>
ipdb> str(to_context['rellinks'][2][1])
'Python Module Index'
```