### PR TITLE
Add dumping of domain data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Releasing
 
 #. Increment the version in ``setup.py``
 #. Tag the release in git: ``git tag $NEW_VERSION``.
-#. Push the tag to GitHub: ``git push --tags origin``
+#. Push the tag to GitHub: ``git push --tags origin master``
 #. Upload the package to PyPI:
 
     .. code:: bash

--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -154,6 +154,7 @@ def generate_json_artifacts(app, pagename, templatename, context, doctree):
 
     This way we can skip generating this in other build step.
     """
+    import ipdb; ipdb.set_trace()
     try:
         if not app.config.rtd_generate_json_artifacts:
             return

--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -150,9 +150,7 @@ def update_body(app, pagename, templatename, context, doctree):
                                                         app.builder.templates)
 
 
-def geneate_search_objects(app, env)
-    import ipdb
-    ipdb.set_trace()
+def geneate_search_objects(app, env):
     domain_objects = {}
     for domainname, domain in sorted(app.env.domains.items()):
         for fullname, dispname, type, docname, anchor, prio in \
@@ -194,7 +192,7 @@ def generate_json_artifacts(app, pagename, templatename, context, doctree):
                 key: context.get(key, '')
                 for key in KEYS
             }
-            to_context['objects'] = env.rtd_domain_objects.get(pagename, {})
+            to_context['objects'] = app.env.rtd_domain_objects.get(pagename, {})
             json.dump(to_context, json_file, indent=4)
     except TypeError:
         log.exception(


### PR DESCRIPTION
This will let us index more interesting data about Sphinx domains in our search.

This will output something like this in the JSON:

```
    "objects": {
        "/api/v2/version/": [
            "http",
            "get",
            "",
            "get--api-v2-version-"
        ],
        "/api/v2/build/(int:id)/": [
            "http",
            "get",
            "",
            "get--api-v2-build-(int-id)-"
        ],
        "/api/v2/project/(int:id)/active_versions/": [
            "http",
            "get",
            "",
            "get--api-v2-project-(int-id)-active_versions-"
        ],
        "/api/v2/version/(int:id)/": [
            "http",
            "get",
            "",
            "get--api-v2-version-(int-id)-"
        ],
        "/api/v2/project/": [
            "http",
            "get",
            "",
            "get--api-v2-project-"
        ],
        "/api/v2/build/": [
            "http",
            "get",
            "",
            "get--api-v2-build-"
        ],
        "/api/v2/project/(int:id)/": [
            "http",
            "get",
            "",
            "get--api-v2-project-(int-id)-"
        ]
    },
```