### PR TITLE
Workaround prospector Python2 bug

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,10 +19,12 @@ commands =
     py.test {posargs}
 
 [testenv:lint]
+# Prospector >= 1.0 does not run under Python2 due to a bug
+# https://github.com/PyCQA/prospector/issues/274
 deps =
     .
     sphinx
-    prospector
+    prospector<1.0
 commands =
     prospector \
     --profile-path={toxinidir} \


### PR DESCRIPTION
This fixes linting on this repo. Prospector installs pylint>=2 which is Python3 only.

See https://github.com/PyCQA/prospector/issues/274.