### PR TITLE
Replace app.info by logging module

### DIFF
--- a/readthedocs_ext/mixins.py
+++ b/readthedocs_ext/mixins.py
@@ -9,6 +9,14 @@ if sphinx.version_info < (1, 5):
 else:
     from sphinx.util.fileutil import copy_asset
 
+try:
+    # Avaliable from Sphinx 1.6
+    from sphinx.util.logging import getLogger
+except ImportError:
+    from logging import getLogger
+
+log = getLogger(__name__)
+
 
 class BuilderMixin(object):  # pylint: disable=old-style-class
 
@@ -25,7 +33,7 @@ class BuilderMixin(object):  # pylint: disable=old-style-class
         return self.globalcontext.copy()
 
     def copy_static_readthedocs_files(self):
-        self.app.info(bold('copying readthedocs static files... '), nonl=True)
+        log.info(bold('copying readthedocs static files... '), nonl=True)
         for filename in self.static_readthedocs_files:
             path_dest = os.path.join(self.outdir, '_static')
             path_src = os.path.join(
@@ -48,7 +56,7 @@ class BuilderMixin(object):  # pylint: disable=old-style-class
                     context=ctx,
                     renderer=self.templates
                 )
-        self.app.info('done')
+        log.info('done')
 
     def copy_static_files(self):
         """Copy Read the Docs specific files after initial static pass

--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -139,7 +139,7 @@ def update_body(app, pagename, templatename, context, doctree):
             if end_body != -1:
                 content = content[:end_body] + rtd_content + "\n" + content[end_body:]
             else:
-                app.debug("File doesn't look like HTML. Skipping RTD content addition")
+                log.debug("File doesn't look like HTML. Skipping RTD content addition")
 
             return content
 
@@ -219,7 +219,7 @@ class HtmlBuilderMixin(BuilderMixin):
         remove automatic initialization. This is a fork of
         ``sphinx.util.fileutil.copy_asset``
         """
-        self.app.info(bold('copying searchtools... '), nonl=True)
+        log.info(bold('copying searchtools... '), nonl=True)
 
         path_src = os.path.join(package_dir, 'themes', 'basic', 'static',
                                 'searchtools.js_t')
@@ -244,8 +244,8 @@ class HtmlBuilderMixin(BuilderMixin):
                         self.get_static_readthedocs_context()
                     ))
         else:
-            self.app.warn('Missing searchtools.js_t')
-        self.app.info('done')
+            log.warning('Missing searchtools.js_t')
+        log.info('done')
 
 
 class ReadtheDocsBuilder(HtmlBuilderMixin, StandaloneHTMLBuilder):

--- a/readthedocs_ext/versionwarning.py
+++ b/readthedocs_ext/versionwarning.py
@@ -21,6 +21,14 @@ from collections import defaultdict
 from sphinx.util.console import red, bold
 from docutils import nodes
 
+try:
+    # Avaliable from Sphinx 1.6
+    from sphinx.util.logging import getLogger
+except ImportError:
+    from logging import getLogger
+
+log = getLogger(__name__)
+
 
 def process_meta(app, doctree, fromdocname):
     env = app.builder.env
@@ -49,7 +57,7 @@ def process_meta(app, doctree, fromdocname):
                         warning = nodes.warning(prose, prose)
                         doctree.insert(0, warning)
                     if app.config['versionwarning-console']:
-                        app.warn(bold('[Version Warning: %s] ' % pagename) + red(text))
+                        log.warning(bold('[Version Warning: %s] ' % pagename) + red(text))
 
 
 def setup(app):


### PR DESCRIPTION
`app.info()`, `app.warn()` and `app.debug()` will be removed in Sphinx-2.0.
`sphinx.util.logging` module should be used instead.