### PR TITLE
Remove media mapping optimization

### DIFF
--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -26,8 +26,6 @@ except ImportError:
 
 log = getLogger(__name__)
 
-
-
 # Whitelist keys that we want to output
 # to the json artifacts.
 KEYS = [

--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -26,11 +26,6 @@ except ImportError:
 
 log = getLogger(__name__)
 
-MEDIA_MAPPING = {
-    "_static/jquery.js": "%sjavascript/jquery/jquery-2.0.3.min.js",
-    "_static/underscore.js": "%sjavascript/underscore.js",
-    "_static/doctools.js": "%sjavascript/doctools.js",
-}
 
 
 # Whitelist keys that we want to output
@@ -55,14 +50,6 @@ def finalize_media(app):
     # Pull project data from conf.py if it exists
     context = app.builder.config.html_context
     MEDIA_URL = context.get('MEDIA_URL', 'https://media.readthedocs.org/')
-
-    # Put in our media files instead of putting them in the docs.
-    for index, file in enumerate(app.builder.script_files):
-        if file in MEDIA_MAPPING.keys():
-            app.builder.script_files[index] = MEDIA_MAPPING[file] % MEDIA_URL
-            if file == "_static/jquery.js":
-                app.builder.script_files.insert(
-                    index + 1, "%sjavascript/jquery/jquery-migrate-1.2.1.min.js" % MEDIA_URL)
 
     app.builder.script_files.append(
         '%sjavascript/readthedocs-doc-embed.js' % MEDIA_URL

--- a/readthedocs_ext/readthedocs.py
+++ b/readthedocs_ext/readthedocs.py
@@ -26,12 +26,6 @@ except ImportError:
 
 log = getLogger(__name__)
 
-MEDIA_MAPPING = {
-    "_static/jquery.js": "%sjavascript/jquery/jquery-2.0.3.min.js",
-    "_static/underscore.js": "%sjavascript/underscore.js",
-    "_static/doctools.js": "%sjavascript/doctools.js",
-}
-
 DEFAULT_STATIC_URL = 'https://assets.readthedocs.org/static/'
 
 # Whitelist keys that we want to output


### PR DESCRIPTION
The `MEDIA_MAPPING` was an optimization that centralizes a few common scripts so that they have a common endpoint across Read the Docs. This way somebody who reads many different docs will request jQuery once and then it is cached on their machine and future docs they read are sped up. In practice, this doesn't actually optimize much because these files are only cached for a week.

The other larger problem with this is that different versions of sphinx bundle different versions of these files. For example, Sphinx v1.4 uses jQuery v1.11.1 while Sphinx v1.5 uses jQuery v3.1.0. Our optimization didn't differentiate different versions of sphinx and do the right thing. 

A side benefit of this PR is that it removes jquery-migrate from Read the Docs. As mentioned in https://github.com/rtfd/readthedocs.org/issues/3226, it is unclear if this is necessary. After this change, it certainly won't be. As long as people use the right version of Sphinx for their build, their build will be the same locally on their system as it will be on RTD.

A second benefit of this PR is that there are some issues with some old versions of jQuery including the version we were including. By removing our mapping to a single version, users will use the version of jquery bundled with the version of Sphinx they are using. By default, RTD uses a modern version of Sphinx and so an up-to-date version of jQuery will be used unless somebody specifically uses an old version.

Fixes https://github.com/rtfd/readthedocs.org/issues/3226
Partially https://github.com/rtfd/readthedocs.org/issues/4999