### PR TITLE
Remove deprecated sudo from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - 2.7
   - 3.5
   - 3.6
-sudo: false
 matrix:
   include:
     - python: 2.7


### PR DESCRIPTION
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration