### PR TITLE
License code as MIT (same as readthedocs.org)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2010-2019 Read the Docs, Inc & contributors
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     author='Read the Docs, Inc',
     author_email='dev@readthedocs.com',
     url='http://github.com/rtfd/readthedocs-sphinx-ext',
-    license='BSD',
+    license='MIT',
     description='Sphinx extension for Read the Docs overrides',
     package_dir={'': '.'},
     packages=find_packages('.'),


### PR DESCRIPTION
As this officially licenses code that I mostly didn't write, I won't merge this without approval from @agjohnson or @ericholscher.

Fixes #59 