### PR TITLE
Escape js vars

### DIFF
--- a/readthedocs_ext/_templates/readthedocs-insert.html.tmpl
+++ b/readthedocs_ext/_templates/readthedocs-insert.html.tmpl
@@ -22,9 +22,9 @@ http://docs.readthedocs.org/en/latest/canonical.html
 
 <!-- Add page-specific data, which must exist in the page js, not global -->
 <script type="text/javascript">
-READTHEDOCS_DATA['page'] = '{{ pagename }}'
+READTHEDOCS_DATA['page'] = {{ pagename|tojson }}
 {%- if page_source_suffix %}
-READTHEDOCS_DATA['source_suffix'] = '{{ page_source_suffix }}'
+READTHEDOCS_DATA['source_suffix'] = {{ page_source_suffix|tojson }}
 {%- endif %}
 </script>
 

--- a/tests/pyexample/escape' this js.rst
+++ b/tests/pyexample/escape' this js.rst
@@ -1,0 +1,4 @@
+Escape JS
+#########
+
+This file name should be escaped before it's included in a `<scrip>` tag.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -71,3 +71,9 @@ class IntegrationTests(LanguageIntegrationTests):
                 'toc', 'sourcename', 'page_source_suffix',
             ],
         )
+
+    def test_escape_js_vars(self):
+        with build_output('pyexample', '_build/readthedocs/escape\' this js.html',
+                          builder='readthedocs') as data:
+            self.assertNotIn('escape \' this js', data)
+            self.assertIn('escape\\u0027 this js', data)


### PR DESCRIPTION
Jinja scapes by default html content, but not js content

Fix https://github.com/rtfd/readthedocs.org/issues/5757