### PR TITLE
Fix linter in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - 3.6
 matrix:
   include:
-    - python: 3.6
+    - python: 2.7
       script: tox -e lint
     - python: 3.7
       dist: xenial


### PR DESCRIPTION
We are still running in py2,
we have py2 code.

We have prospector pinned to a version compatible with py2

The PR that introduced this change passed somehow https://github.com/rtfd/readthedocs-sphinx-ext/pull/67
I guess some travis cache.